### PR TITLE
fix: point Dependabot to proper Dockerfiles

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,9 +16,16 @@ updates:
     open-pull-requests-limit: 10
     versioning-strategy: auto
 
-  # Check for updates to Docker
+  # Check for updates to Docker in web package
   - package-ecosystem: "docker"
-    directory: "/"
+    directory: "/packages/web"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 5
+
+  # Check for updates to Docker in cms package
+  - package-ecosystem: "docker"
+    directory: "/packages/cms"
     schedule:
       interval: "monthly"
     open-pull-requests-limit: 5


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated dependency management configuration to monitor Docker updates separately for the web and CMS packages, each with its own schedule and pull request limit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->