### PR TITLE
chore: reduce hover card open delay for improved responsiveness

### DIFF
--- a/packages/web/src/modules/glossary-item-info/component.tsx
+++ b/packages/web/src/modules/glossary-item-info/component.tsx
@@ -17,7 +17,7 @@ export function GlossaryItemInfoComponent({
   const { isCardOpen, handleOpenChange, toggleOpen } = useHoverCardState(onOpenChange);
 
   return (
-    <HoverCard openDelay={150} open={isCardOpen} onOpenChange={handleOpenChange}>
+    <HoverCard openDelay={50} open={isCardOpen} onOpenChange={handleOpenChange}>
       <HoverCardTrigger asChild onClick={toggleOpen}>
         <span className="underline cursor-help">{name}</span>
       </HoverCardTrigger>

--- a/packages/web/src/modules/quadrant-plot/component.tsx
+++ b/packages/web/src/modules/quadrant-plot/component.tsx
@@ -195,7 +195,7 @@ const QuadrantPlotHoverCard = ({
   scoreLabels,
 }: QuadrantPlotHoverCardProps) => {
   return (
-    <HoverCard openDelay={150}>
+    <HoverCard openDelay={50}>
       <HoverCardTrigger asChild>
         <div
           className="absolute pointer-events-auto"

--- a/packages/web/src/modules/question-explanation/component.tsx
+++ b/packages/web/src/modules/question-explanation/component.tsx
@@ -17,7 +17,7 @@ export function QuestionExplanationComponent({
   const { isCardOpen, handleOpenChange, toggleOpen } = useHoverCardState(onOpenChange);
 
   return (
-    <HoverCard openDelay={150} open={isCardOpen} onOpenChange={handleOpenChange}>
+    <HoverCard openDelay={50} open={isCardOpen} onOpenChange={handleOpenChange}>
       <HoverCardTrigger asChild onClick={toggleOpen}>
         <Button variant="ghost" size="icon" className="rounded-full" asChild>
           <HelpCircle className="text-primary w-6 h-6 ml-4" />


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Reduced the delay before hover cards appear across multiple components, making hover cards open more quickly in the glossary, quadrant plot, and question explanation sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->